### PR TITLE
Fix format string bug

### DIFF
--- a/src/ingest/radar/circbuff_to_nc/circbuffer_to_netcdf.c
+++ b/src/ingest/radar/circbuff_to_nc/circbuffer_to_netcdf.c
@@ -255,7 +255,8 @@ int i_status;
 
    }
 
-  fprintf(stdout,buf,"%s","\n");
+  /* Print the command being issued */
+  fprintf(stdout, "%s\n", buf);
 
   p1= popen(buf,"r");  
 

--- a/src/ingest/radar/remap/remap.c
+++ b/src/ingest/radar/remap/remap.c
@@ -252,7 +252,8 @@ int i_status;
 
    }
 
-  fprintf(stdout,buf,"%s","\n");
+  /* Print the command being issued */
+  fprintf(stdout, "%s\n", buf);
 
   p1= popen(buf,"r");  
 


### PR DESCRIPTION
## Summary
- fix `fprintf` format string misuse in radar utilities

## Testing
- `gcc -fsyntax-only -I./src/include src/ingest/radar/remap/remap.c`
- `gcc -fsyntax-only -I./src/include src/ingest/radar/circbuff_to_nc/circbuffer_to_netcdf.c` *(fails: config.h missing)*