### PR TITLE
Add M1 mac clang & gfortran support

### DIFF
--- a/README
+++ b/README
@@ -181,9 +181,15 @@
      LINUX (i386,i686,x86_64)          pgf90 is suggested
                                        ifort (version 12.0.4 or later)
                                        gfortran being tested
-     LINUX (MacOS-X)                   pgf90 is being tested
+    macOS (Intel/x86_64 and Apple Silicon/arm64)
+                                      clang and gfortran supported
      LINUX (Alpha)                     fort is suggested  
 </pre>
+
+    When building on macOS systems, ensure that the `clang` C compiler and
+    `gfortran` are available in your `PATH` (these can be installed via
+    Homebrew).  The configure script now recognizes the `arm64` architecture
+    used by Apple Silicon Macs.
 
      We are working on adding more supported platforms. We welcome suggestions
      on how to modify LAPS for other platforms/versions. Note that we cannot 

--- a/configure
+++ b/configure
@@ -1512,7 +1512,7 @@ then
   W3="-DLINUX"
 fi  
 
-if test "$arch" = "unknown" 
+if test "$arch" = "unknown" || test "$arch" = "arm64" || test "$arch" = "aarch64"
 then
   if test "`/usr/bin/uname -s`" = "Darwin"
   then
@@ -1605,7 +1605,7 @@ $FC
 EOF
 if test $? -eq 0
 then
-    FFLAGS="$FFLAGS -fd-lines-as-comments -ffree-line-length-none -finit-local-zero"
+    FFLAGS="$FFLAGS -fd-lines-as-comments -ffree-line-length-none -finit-local-zero -fallow-argument-mismatch"
     DBFLAGS="$DBFLAGS -fcheck=all -Wall"
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -235,7 +235,7 @@ then
 fi  
 
 dnl  For W3 and CFLAGS, test for MAC (Darwin)
-if test "$arch" = "unknown" 
+if test "$arch" = "unknown" || test "$arch" = "arm64" || test "$arch" = "aarch64"
 then
   if test "`/usr/bin/uname -s`" = "Darwin"
   then
@@ -339,7 +339,8 @@ $FC
 EOF
 if test $? -eq 0
 then
-    FFLAGS="$FFLAGS -fd-lines-as-comments -ffree-line-length-none"
+    FFLAGS="$FFLAGS -fd-lines-as-comments -ffree-line-length-none -finit-local-zero -fallow-argument-mismatch"
+    DBFLAGS="$DBFLAGS -fcheck=all -Wall"
 fi
 
 dnl  Check to see if we are running the lahey


### PR DESCRIPTION
## Summary
- document clang and gfortran usage on macOS, including Apple Silicon
- adjust configure scripts to detect arm64/aarch64
- add gfortran flags for compatibility

## Testing
- `./configure --help`