### PR TITLE
Enable OpenMP hybrid with MPI

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -226,7 +226,8 @@ then
     C_OPT="-O2"
     F_OPT="-O2 -fastsse"
   fi
-fi  
+  CPPFLAGS="$CPPFLAGS -DUSEMPI"
+fi
 
 dnl  For W3, test for LINUX build
 if test "$arch" = "x86_64" || test "$arch" = "i686" || test "$arch" = "i386"

--- a/src/include/makefile.inc.in
+++ b/src/include/makefile.inc.in
@@ -5,8 +5,8 @@ INSTALLROOT=@prefix@
 DATAROOT=@datadir@
 CC=@CC@
 
-CFLAGS=@CFLAGS@  @C_OPT@ 
-DBCFLAGS=@CFLAGS@ @DBCFLAGS@ -DDEBUG=1
+CFLAGS=@CFLAGS@  @C_OPT@ -fopenmp 
+DBCFLAGS=@CFLAGS@ @DBCFLAGS@ -DDEBUG=1 -fopenmp
 
 
 
@@ -16,11 +16,11 @@ FC       = @FC@
 #
 NCARGFC  = @NCARGFC@
 
-FFLAGS = @FFLAGS@ $(INC) @F_OPT@
-LITTLEFLAGS = @LITTLEFLAGS@ $(INC) @F_OPT@
+FFLAGS = @FFLAGS@ $(INC) @F_OPT@ -fopenmp
+LITTLEFLAGS = @LITTLEFLAGS@ $(INC) @F_OPT@ -fopenmp
 FREE = @FREE@
 FIXED = @FIXED@
-DBFLAGS = @FFLAGS@ $(INC) @DBFLAGS@ 
+DBFLAGS = @FFLAGS@ $(INC) @DBFLAGS@ -fopenmp 
 
 # Define pre-processor command line options for .F files.
 

--- a/src/lib/barnes_multivariate.F
+++ b/src/lib/barnes_multivariate.F
@@ -762,7 +762,6 @@ cdis
 
               if(kmax .gt. 1)then ! 3D field analysis
 
-csms$parallel(grid_dh, <ii>) begin
 
                   if(n_var .eq. 2)then ! wind analysis
                     if(kk .ge. k)then
@@ -791,6 +790,7 @@ csms$parallel(grid_dh, <ii>) begin
                       varl1 = varl(1)
                       varl2 = varl(2)
 
+!$omp parallel do private(ii,jj,weight_i,weight_term_i,weight,weight_varl1,weight_varl2)
                       do ii=ilow,ihigh
 
 !                       The exp_m_offset prevents applying the scaling twice
@@ -811,6 +811,7 @@ csms$parallel(grid_dh, <ii>) begin
 
                         enddo ! jj
                       enddo ! ii
+!$omp end parallel do
 
                     elseif(kk_higher_pair .eq. 1)then ! double up the k s
                       varl1 = varl(1)
@@ -874,6 +875,7 @@ csms$parallel(grid_dh, <ii>) begin
                       enddo ! jj
 
                   else ! generic slightly less efficient method
+!$omp parallel do collapse(2) private(ii,jj,l,weight)
                       do jj=jlow,jhigh
                       do ii=ilow,ihigh
                           weight = fnorm_lut(ii-i,jj-j) * weight_term
@@ -886,17 +888,17 @@ csms$parallel(grid_dh, <ii>) begin
 
                       enddo ! ii
                       enddo ! jj
+!$omp end parallel do
 
                   endif
-csms$parallel end
+
 
               else ! sfc analysis - add in landfrac weight
 
-csms$parallel(grid_dh, <ii>) begin
+!$omp parallel do private(ii,jj,weight,weight_landfrac,const,diffl)
 !                 weight_landfrac = 1.
                   if(n_var .gt. 1)then
                       stop
-csms$exit
                   endif
 
                   do jj=jlow,jhigh
@@ -954,7 +956,7 @@ C
 
                   enddo ! ii
                   enddo ! jj
-csms$parallel end
+!$omp end parallel do
 
               endif ! 3D or sfc analysis
           enddo ! k
@@ -967,26 +969,20 @@ csms$parallel end
 !     Divide the weights
       do k=1,kmax
 
-csms$parallel(grid_dh, <i>) begin
+!$omp parallel do collapse(2) private(i,j,l)
           do j=1,jmax
           do i=1,imax
               do l = 1,n_var
                   if(sumwt(i,j,k) + wt_b(i,j,k,l) .eq. 0.)then
-csms$remove begin
-                      var(i,j,k,l) = r_missing_data
-csms$remove end
-csms$insert           var(i,j,k+(l-1)*kmax) = r_missing_data
+                      var(i,j,k+(l-1)*kmax) = r_missing_data
                   else
-csms$remove begin
-                      var(i,j,k,l)=sum_var(l,i,j,k) * relax
-csms$remove end
-csms$insert           var(i,j,k+(l-1)*kmax)=sum_var(l,i,j,k) * relax
+                      var(i,j,k+(l-1)*kmax)=sum_var(l,i,j,k) * relax
      1                          / (sumwt(i,j,k) + wt_b(i,j,k,l))
                   endif
               enddo ! l
           enddo ! i
           enddo ! j
-csms$parallel end
+!$omp end parallel do
 
           write(6,*)' Divided level ',k
 
@@ -1129,8 +1125,8 @@ csms$parallel end
       ncnt_total=0
       weight_total = 0.
 
-csms$insert      call nnt_me(me)
-csms$insert      print *, 'got to arrays_to_barnesobs1 processor=',me       
+! call nnt_me(me)
+! print *, 'got to arrays_to_barnesobs1 processor=',me
 
 !     Count obs and map obs into data structure
       do k=1,kmax
@@ -1171,8 +1167,8 @@ csms$insert      print *, 'got to arrays_to_barnesobs1 processor=',me
       enddo ! j
       enddo ! k
 
-csms$insert      call nnt_me(me)
-csms$insert      print *, 'got to arrays_to_barnesobs2 processor=',me       
+! call nnt_me(me)
+! print *, 'got to arrays_to_barnesobs2 processor=',me
 
       istatus = 1
       return


### PR DESCRIPTION
## Summary
- add `-DUSEMPI` when mpif90 detected
- convert legacy csms$ parallel directives to valid OpenMP loops in `barnes_multivariate.F`

## Testing
- `make -n -C src/lib` *(fails: `No rule to make target '../../src/include/makefile.inc'`)*