### PR TITLE
Handle errors in OpenMP loops for wind analysis

### DIFF
--- a/src/wind/windanal.f
+++ b/src/wind/windanal.f
@@ -181,6 +181,7 @@ cdis
       integer istatus         ! (1 is good)                          ! Output
 
       integer  n_fnorm_dum
+      logical missing_flag
 
 !****************END DECLARATIONS *********************************************
 
@@ -812,20 +813,27 @@ csms$serial(default=ignore)  begin
 
       do k=1,kmax ! Add back differences for first pass
 
+      missing_flag = .false.
+!$omp parallel do collapse(2) private(i,j) reduction(.or.:missing_flag)
           do j=1,jmax
           do i=1,imax
-              if(upass1(i,j,k) .ne. r_missing_data)then
-                  upass1(i,j,k) = upass1(i,j,k) + u_laps_bkg(i,j,k)
-                  vpass1(i,j,k) = vpass1(i,j,k) + v_laps_bkg(i,j,k)
-              else
-                  write(6,*)
-     1            ' ERROR: Missing data value(s) detected in first'
-     1           ,' pass at lvl',k
-                  istatus = 0
-                  return
-              endif
+            if(upass1(i,j,k) .ne. r_missing_data)then
+                upass1(i,j,k) = upass1(i,j,k) + u_laps_bkg(i,j,k)
+                vpass1(i,j,k) = vpass1(i,j,k) + v_laps_bkg(i,j,k)
+            else
+                missing_flag = .true.
+            endif
           enddo ! i
           enddo ! j
+!$omp end parallel do
+
+          if(missing_flag)then
+              write(6,*)
+     1        ' ERROR: Missing data value(s) detected in first',
+     1       ' pass at lvl',k
+              istatus = 0
+              return
+          endif
 
 
           if(l_analyze(k) .OR. (.true. .and. icount_radar_total .gt. 0) ! l_3d
@@ -833,6 +841,7 @@ csms$serial(default=ignore)  begin
               write(6,511)k
 511           format(' Use 2nd Pass for lvl',i3)
 
+!$omp parallel do collapse(2) private(i,j)
               do j=1,jmax
               do i=1,imax
                   uanl(i,j,k) = uanl(i,j,k) + u_laps_bkg(i,j,k)
@@ -840,10 +849,12 @@ csms$serial(default=ignore)  begin
 
               enddo ! i
               enddo ! j
+!$omp end parallel do
 
           else
               write(6,512)k
 512           format(' Use 1st Pass for lvl',i3)
+!$omp parallel do collapse(2) private(i,j)
               do j=1,jmax
               do i=1,imax
                   uanl(i,j,k) = upass1(i,j,k)
@@ -851,6 +862,7 @@ csms$serial(default=ignore)  begin
 
               enddo ! i
               enddo ! j
+!$omp end parallel do
 
           endif
       enddo ! k


### PR DESCRIPTION
## Summary
- ensure surface interpolation errors are reported outside of OpenMP loop
- check for missing data in wind analysis after threads complete

## Testing
- `make -n` *(fails: No rule to make target 'src/include/makefile.inc')*